### PR TITLE
Fix ftplugin syntax issues

### DIFF
--- a/bundle/tremor.vim/ftplugin/tremor.vim
+++ b/bundle/tremor.vim/ftplugin/tremor.vim
@@ -2,7 +2,9 @@
 " Language:     Tremor
 " Maintainer:   Darach Ennis
 
-if exists('b:did_ftplugin') finish endif
+if exists('b:did_ftplugin')
+  finish
+endif
 
 let s:cpo_save = &cpo
 set cpo&vim
@@ -16,8 +18,8 @@ setlocal shiftwidth=2
 
 let b:match_ignorecase = 0
 let b:match_skip = 's:Comment\|String\|CaseGuard'
-let b:match_words = '\v<%(emit|drop|let|match|of|case|when|default|patch|insert|update|upsert|erase|merge|patch|for|end|event)>
+let b:match_words = '\v<%(emit|drop|let|match|of|case|when|default|patch|insert|update|upsert|erase|merge|patch|for|end|event)>'
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-let b:did_ftplugin = 1'
+let b:did_ftplugin = 1


### PR DESCRIPTION
was running into errors during vim startup without these changes

```
"log.tremor" 73L, 3416C
Error detected while processing /home/anup/repos/DOTFILES/data/.vim/plugged/tremor-vim/ftplugin/tremor.vim:
line    5:
E15: Invalid expression: exists('b:did_ftplugin') finish endif
line   24:
E171: Missing :endif
```

```
$ vim --version                                                                                   
VIM - Vi IMproved 8.1 (2018 May 18, compiled Jul 25 2019 08:18:55)                                                                                 
```

will help me keep my vimrc clean 😃 
https://github.com/anupdhml/dotfiles/blob/virtualbox_new/data/.vimrc#L102